### PR TITLE
Fix incorrect catalog link in mobile navigation

### DIFF
--- a/app/views/layout.php
+++ b/app/views/layout.php
@@ -135,7 +135,7 @@ $role = $user['role'] ?? 'guest';
           <?php if (in_array($role, ['admin','collector'], true)): ?>
             <div class="px-3 py-1 text-xs uppercase text-slate-500">Číselníky</div>
             <a class="block px-3 py-2 text-sm hover:bg-slate-800" href="<?= Url::build('periods/list') ?>">Období</a>
-            <a class="block px-3 py-2 text-sm hover:bg-slate-800" href="<?= Url::build('catalog/list') ?>">Katalog</a>
+            <a class="block px-3 py-2 text-sm hover:bg-slate-800" href="<?= Url::build('catalogs/list') ?>">Katalog</a>
           <?php endif; ?>
 
           <?php if ($role === 'collector'): ?>


### PR DESCRIPTION
## Summary
- correct mobile menu link to catalog list

## Testing
- `php -l app/views/layout.php`
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_689f477a84748323a40b91308958834f