### PR TITLE
Fix catalog path in mobile navigation

### DIFF
--- a/app/views/layout.php
+++ b/app/views/layout.php
@@ -135,7 +135,7 @@ $role = $user['role'] ?? 'guest';
           <?php if (in_array($role, ['admin','collector'], true)): ?>
             <div class="px-3 py-1 text-xs uppercase text-slate-500">Číselníky</div>
             <a class="block px-3 py-2 text-sm hover:bg-slate-800" href="<?= Url::build('periods/list') ?>">Období</a>
-            <a class="block px-3 py-2 text-sm hover:bg-slate-800" href="<?= Url::build('catalog/list') ?>">Katalog</a>
+            <a class="block px-3 py-2 text-sm hover:bg-slate-800" href="<?= Url::build('catalogs/list') ?>">Katalog</a>
           <?php endif; ?>
 
           <?php if ($role === 'collector'): ?>


### PR DESCRIPTION
## Summary
- Use `catalogs/list` path in mobile navigation to match desktop menu

## Testing
- `php -l app/views/layout.php`


------
https://chatgpt.com/codex/tasks/task_e_689f49db7af48323b0c30a61b7d349bc