### PR TITLE
Restrict period year fields to 0-9999

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,4 +122,8 @@ v0.7 – Období: audit + soft‑delete + filtry (08.08.2025)
 - Odstraněn odkaz „Zapomenuté heslo“
 - Odstraněn duplicitní text „© Coin Manager“ z login stránky
 - Přidána metoda `findByUsername()` do modelu `User`
-- Úprava kontroleru přihlášení (`AuthController`) pro práci s uživatelským jménem
+ - Úprava kontroleru přihlášení (`AuthController`) pro práci s uživatelským jménem
+
+## V 1.1.1 – validace roku u období
+- Formulář období: pole „Rok od“ a „Rok do“ přijímají pouze čísla 0–9999 (max 4 znaky).
+- Serverová validace let byla omezena na rozsah 0–9999.

--- a/app/controllers/PeriodsController.php
+++ b/app/controllers/PeriodsController.php
@@ -107,8 +107,8 @@ public function list(): void
         if ($e = Validator::str($data['name'], 64, true))     $errors['name'] = $e;
         if ($e = Validator::str($data['description'], 255))   $errors['description'] = $e;
         // note = TEXT → bez limitu (DB limit textu je vysoký), necháme jen trim
-        if ($e = Validator::nullableInt($data['yearFrom'], -5000, 9999)) $errors['yearFrom'] = $e;
-        if ($e = Validator::nullableInt($data['yearTo'],   -5000, 9999)) $errors['yearTo']   = $e;
+        if ($e = Validator::nullableInt($data['yearFrom'], 0, 9999)) $errors['yearFrom'] = $e;
+        if ($e = Validator::nullableInt($data['yearTo'],   0, 9999)) $errors['yearTo']   = $e;
 
 
         // logická vazba roku
@@ -181,8 +181,8 @@ public function list(): void
         if ($e = Validator::str($data['display'], 255, true)) $errors['display'] = $e;
         if ($e = Validator::str($data['name'], 64, true))     $errors['name'] = $e;
         if ($e = Validator::str($data['description'], 255))   $errors['description'] = $e;
-        if ($e = Validator::nullableInt($data['yearFrom'], -5000, 9999)) $errors['yearFrom'] = $e;
-        if ($e = Validator::nullableInt($data['yearTo'],   -5000, 9999)) $errors['yearTo']   = $e;
+        if ($e = Validator::nullableInt($data['yearFrom'], 0, 9999)) $errors['yearFrom'] = $e;
+        if ($e = Validator::nullableInt($data['yearTo'],   0, 9999)) $errors['yearTo']   = $e;
         if ($data['yearFrom'] !== '' && $data['yearTo'] !== '' && (int)$data['yearFrom'] > (int)$data['yearTo']) {
             $errors['yearTo'] = 'Rok „do“ musí být ≥ „od“.';
         }

--- a/app/views/periods/form.php
+++ b/app/views/periods/form.php
@@ -52,7 +52,7 @@ $action = $isEdit ? 'index.php?route=periods/update' : 'index.php?route=periods/
       <label class="block">
         <span class="mb-1 block text-sm text-slate-300">Rok od</span>
         <input class="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm"
-               type="text" name="yearFrom" inputmode="numeric"
+               type="text" name="yearFrom" inputmode="numeric" pattern="[0-9]{0,4}" maxlength="4"
                value="<?= htmlspecialchars((string)($item['yearFrom'] ?? '')) ?>">
         <?php if (!empty($errors['yearFrom'])): ?>
           <div class="mt-1 text-xs text-red-300"><?= htmlspecialchars($errors['yearFrom']) ?></div>
@@ -62,7 +62,7 @@ $action = $isEdit ? 'index.php?route=periods/update' : 'index.php?route=periods/
       <label class="block">
         <span class="mb-1 block text-sm text-slate-300">Rok do</span>
         <input class="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm"
-               type="text" name="yearTo" inputmode="numeric"
+               type="text" name="yearTo" inputmode="numeric" pattern="[0-9]{0,4}" maxlength="4"
                value="<?= htmlspecialchars((string)($item['yearTo'] ?? '')) ?>">
         <?php if (!empty($errors['yearTo'])): ?>
           <div class="mt-1 text-xs text-red-300"><?= htmlspecialchars($errors['yearTo']) ?></div>


### PR DESCRIPTION
## Summary
- limit period form year inputs to 0-9999 digits
- tighten server-side year validation
- document change in changelog

## Testing
- `php -l app/controllers/PeriodsController.php`
- `php -l app/views/periods/form.php`


------
https://chatgpt.com/codex/tasks/task_e_68b46214af0c8323abf70c86d99480ce